### PR TITLE
Add TableRowClassifier

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -75,7 +75,7 @@ jobs:
           conda install -y pyopencl
           python -m pip install --upgrade pip
           # pip install setuptools tox tox-gh-actions
-          pip install setuptools wheel pytest pytest-cov pytest-benchmark pytest-qt pyqt5 pytest-xvfb
+          pip install setuptools wheel pytest pytest-cov pytest-benchmark pytest-qt pyqt5 pytest-xvfb pandas
 
           pip install -e .
       # this runs the platform-specific tests declared in tox.ini

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![tests](https://github.com/haesleinhuepf/apoc/workflows/tests/badge.svg)](https://github.com/haesleinhuepf/apoc/actions)
 [![codecov](https://codecov.io/gh/haesleinhuepf/apoc/branch/main/graph/badge.svg)](https://codecov.io/gh/haesleinhuepf/apoc)
 [![Development Status](https://img.shields.io/pypi/status/apoc.svg)](https://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha)
+[![DOI](https://zenodo.org/badge/412505712.svg)](https://zenodo.org/badge/latestdoi/412505712)
 
 [clesperanto](https://github.com/clEsperanto/pyclesperanto_prototype) meets [scikit-learn](https://scikit-learn.org/stable/) to classify pixels and objects in images, on a [GPU](https://en.wikipedia.org/wiki/Graphics_processing_unit) using [OpenCL](https://www.khronos.org/opencl/).
 This repository contains the backend for python developers. User-friendly plugins for [Fiji](https://fiji.sc) and [napari](https://napari.org) can be found here:

--- a/apoc/__init__.py
+++ b/apoc/__init__.py
@@ -3,6 +3,7 @@ from ._pixel_classifier import PixelClassifier
 from ._object_segmenter import ObjectSegmenter
 from ._object_classifier import ObjectClassifier
 from ._probability_mapper import ProbabilityMapper
+from ._table_row_classifier import TableRowClassifier
 from ._utils import generate_feature_stack
 from ._utils import erase_classifier
 from ._utils import list_available_object_classification_features

--- a/apoc/_object_classifier.py
+++ b/apoc/_object_classifier.py
@@ -70,15 +70,6 @@ class ObjectClassifier():
         selected_features, _ = self._make_features(self.classifier.feature_specification, labels, None, image)
         output = self.classifier.predict(selected_features, return_numpy=False)
 
-        # output = cle.create_like(selected_features[0].shape)
-        # parameters = {}
-        # for i, f in enumerate(selected_features):
-        #     parameters['in' + str(i)] = cle.push(f)
-        #
-        # parameters['out'] = output
-        #
-        # cle.execute(None, self.classifier.opencl_file, "predict", selected_features[0].shape, parameters)
-        #
         # set background to zero
         cle.set_column(output, 0, 0)
 

--- a/apoc/_pixel_classifier.py
+++ b/apoc/_pixel_classifier.py
@@ -270,7 +270,6 @@ class PixelClassifier():
 
         return features
 
-
     def statistics(self):
         """Provide statistics about the trained Random Forest Classifier
 

--- a/apoc/_table_row_classifier.py
+++ b/apoc/_table_row_classifier.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 
 import numpy as np
 
@@ -6,7 +6,12 @@ from ._pixel_classifier import PixelClassifier
 
 
 class TableRowClassifier():
-    def __init__(self, opencl_filename="temp_object_classifier.cl", max_depth: int = 2, num_ensembles: int = 10):
+    def __init__(
+            self,
+            opencl_filename="temp_object_classifier.cl",
+            max_depth: int = 2, num_ensembles: int = 10,
+            overwrite_classname: Optional[str] = None,
+    ):
         """A RandomForestClassifier for classifying rows of a table that converts itself to OpenCL after training.
 
         Parameters
@@ -23,11 +28,14 @@ class TableRowClassifier():
         """
         self._ordered_feature_names = []
 
+        if overwrite_classname is None:
+            overwrite_classname = self.__class__.__name__
+        self._classifier_classname = overwrite_classname
         self.classifier = PixelClassifier(
             opencl_filename=opencl_filename,
             max_depth=max_depth,
             num_ensembles=num_ensembles,
-            overwrite_classname=self.__class__.__name__
+            overwrite_classname=self.classifier_classname
         )
 
     @property
@@ -42,6 +50,19 @@ class TableRowClassifier():
             A list of the feature names in the order they are expected by the classifer.
         """
         return self._ordered_feature_names
+
+    @property
+    def classifier_classname(self) -> str:
+        """The name used for the classifier class.
+
+        This is set in the __init__ by the overwrite_classname kwarg.
+
+        Returns
+        -------
+        classifier_classname : str
+            The name used for the classifier class.
+        """
+        return self._classifier_classname
 
     def train(
         self,
@@ -66,7 +87,7 @@ class TableRowClassifier():
         """
         ordered_features = self._prepare_feature_table(feature_table)
         self.classifier.train(ordered_features, gt, continue_training=continue_training)
-        self.classifier.to_opencl_file(self.classifier.opencl_file, overwrite_classname=self.__class__.__name__)
+        self.classifier.to_opencl_file(self.classifier.opencl_file, overwrite_classname=self.classifier_classname)
 
     def predict(
             self,
@@ -138,6 +159,7 @@ class TableRowClassifier():
             # if the feature names haven't previously been stored,
             # store them as a list
             self._ordered_feature_names = list(feature_table.keys())
+            self.classifier.feature_specification = " ".join(self.ordered_feature_names)
         return self.order_feature_table(feature_table)
 
     def order_feature_table(self, feature_table: Dict[str, np.ndarray]) -> List[np.ndarray]:
@@ -157,3 +179,29 @@ class TableRowClassifier():
             specified by self.ordered_feature_names
         """
         return [np.asarray(feature_table[feature]) for feature in self.ordered_feature_names]
+
+    def statistics(self):
+        """Provide statistics about the trained Random Forest Classifier
+
+        After training or loading a model, this function reads out the decision trees and generates
+        statistics from it. It counts for each decision depth how often given features are taken into
+        account. It returns two dictionaries. Both dictionaries contain the feature names used during
+        training as keys. The values are lists with numbers: The first 'ratios' dictionary contains
+        numbers between 0 and 1. The higher that number, the more often is the given feature taken
+        into account on the given decision level. The second 'count' dictionary contains the count of
+        decisions taking a given feature into account. For example in case the result looks like this:
+
+        A: [0.3, 0.1], [30, 20]
+        B: [0.7, 0.9], [70, 180]
+
+        Feature A was taken into account 30% of the decision trees on the first level and in 10% on
+        the second level. In case of 100 trees, these are 30 trees on the first level and can be up
+        to 20 trees on the second level. Each level doubles the number of available decisions in these
+        binary decision trees.
+
+        Returns
+        -------
+        ratios: dict
+        counts: dict
+        """
+        return self.classifier.statistics()

--- a/apoc/_table_row_classifier.py
+++ b/apoc/_table_row_classifier.py
@@ -8,7 +8,7 @@ from ._pixel_classifier import PixelClassifier
 class TableRowClassifier():
     def __init__(
             self,
-            opencl_filename="temp_object_classifier.cl",
+            opencl_filename="temp_table_row_classifier.cl",
             max_depth: int = 2, num_ensembles: int = 10,
             overwrite_classname: Optional[str] = None,
     ):

--- a/apoc/_table_row_classifier.py
+++ b/apoc/_table_row_classifier.py
@@ -5,7 +5,7 @@ import numpy as np
 from ._pixel_classifier import PixelClassifier
 
 
-class TableRowClassifier():
+class TableRowClassifier:
     def __init__(
             self,
             opencl_filename="temp_table_row_classifier.cl",

--- a/apoc/_table_row_classifier.py
+++ b/apoc/_table_row_classifier.py
@@ -1,0 +1,116 @@
+from typing import Dict, List, Union
+
+import numpy as np
+
+from ._pixel_classifier import PixelClassifier
+
+
+class TableRowClassifier():
+    def __init__(self, opencl_filename="temp_object_classifier.cl", max_depth: int = 2, num_ensembles: int = 10):
+        """
+        A RandomForestClassifier for label classification that converts itself to OpenCL after training.
+
+        Parameters
+        ----------
+        opencl_filename : str (optional)
+        max_depth : int (optional)
+        num_ensembles : int (optional)
+
+        See Also
+        --------
+            https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html
+        """
+        self._ordered_feature_names = []
+
+        self.classifier = PixelClassifier(
+            opencl_filename=opencl_filename,
+            max_depth=max_depth,
+            num_ensembles=num_ensembles,
+            overwrite_classname=self.__class__.__name__
+        )
+
+    @property
+    def ordered_feature_names(self) -> List[str]:
+        """
+        Returns
+        -------
+        ordered_feature_names : List[str]
+            A list of the feature names in the order they are expected by the classifer.
+        """
+        return self._ordered_feature_names
+
+    def train(self, feature_table: Dict[str, Union[List[float], np.ndarray]], gt: np.ndarray, continue_training: bool = False):
+        """
+        Train a classifier that can differentiate label types according to intensity, size and shape.
+
+        Parameters
+        ----------
+        features: Space separated string containing those:
+            'area',
+            'min_intensity', 'max_intensity', 'sum_intensity', 'mean_intensity', 'standard_deviation_intensity',
+            'mass_center_x', 'mass_center_y', 'mass_center_z',
+            'centroid_x', 'centroid_y', 'centroid_z',
+            'max_distance_to_centroid', 'max_distance_to_mass_center',
+            'mean_max_distance_to_centroid_ratio', 'mean_max_distance_to_mass_center_ratio',
+            'touching_neighbor_count', 'average_distance_of_touching_neighbors', 'average_distance_of_n_nearest_neighbors'
+        labels: label image
+        sparse_annotation: label image with annotations. If one label is annotated with multiple classes, the
+            maximum is considered while training.
+        image: intensity image (optional)
+
+        """
+        ordered_features = self._prepare_feature_table(feature_table)
+        self.classifier.train(ordered_features, gt, continue_training=continue_training)
+        self.classifier.to_opencl_file(self.classifier.opencl_file, overwrite_classname=self.__class__.__name__)
+
+    def predict(
+            self,
+            feature_table: Dict[str, Union[List[float], np.ndarray]],
+            return_numpy: bool = True
+    ) -> List[int]:
+        """Predict object class from label image and optional intensity image.
+
+        Parameters
+        ----------
+        labels: label image
+        image: intensity image
+
+        Returns
+        -------
+        label image representing a semantic segmentation: pixel intensities represent label class
+
+        """
+        import pyclesperanto_prototype as cle
+
+        ordered_features = self.order_feature_table(feature_table)
+
+        # allocate the result
+        output = cle.create_like(ordered_features[0].shape)
+
+        # push the features
+        parameters = {}
+        for i, f in enumerate(ordered_features):
+            parameters['in' + str(i)] = cle.push(f)
+        parameters['out'] = output
+
+        # run the classifier
+        cle.execute(None, self.classifier.opencl_file, "predict", ordered_features[0].shape, parameters)
+
+        if return_numpy is True:
+            return np.asarray(output, dtype=np.uint32)
+        else:
+            return output
+
+    def _prepare_feature_table(self, feature_table) -> List[np.ndarray]:
+        if len(self._ordered_feature_names) == 0:
+            # if the feature names haven't previously been stored,
+            # store them as a list
+            self._ordered_feature_names = list(feature_table.keys())
+        ordered_feature_names = self._ordered_feature_names
+        return [
+            np.asarray(feature_table[feature_name]) for feature_name in ordered_feature_names
+        ]
+
+    def order_feature_table(self, feature_table: Dict[str, np.ndarray]) -> List[np.ndarray]:
+        return [np.asarray(feature_table[feature]) for feature in self.ordered_feature_names]
+

--- a/demo/table_row_classification.ipynb
+++ b/demo/table_row_classification.ipynb
@@ -1,0 +1,207 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2c22cc5b",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates using the apoc `TableRowClasifer`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "501dff50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import apoc\n",
+    "import numpy as np\n",
+    "from numpy.random import default_rng\n",
+    "from skimage import draw\n",
+    "from skimage.measure import regionprops_table\n",
+    "import pyclesperanto_prototype as cle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "736b80bb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<pthread-Intel(R) Xeon(R) W-2125 CPU @ 4.00GHz on Platform: Portable Computing Language (2 refs)>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cle.select_device()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "63b93049",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_square_indices(center_row, center_column, half_width=5):\n",
+    "    \"\"\"Get the indices to fill in a square\"\"\"\n",
+    "    start = np.array([center_row, center_column]) - half_width\n",
+    "    extent = (2 * half_width, 2 * half_width)\n",
+    "    return draw.rectangle(start, extent=extent)\n",
+    "\n",
+    "\n",
+    "def get_circle_indices(center_row, center_column, half_width=5):\n",
+    "    \"\"\"Get the indices to fill in a circle\"\"\"\n",
+    "    center = (center_row, center_column)\n",
+    "    radius = half_width\n",
+    "    return draw.disk(center, radius)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6e127674",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a label image with randomly placed squares and circles\n",
+    "rng = default_rng(42)\n",
+    "\n",
+    "label_image = np.zeros((200, 200), dtype=np.uint16)\n",
+    "\n",
+    "label_index = 1\n",
+    "ground_truth = []\n",
+    "for center_row in np.arange(10, 200, 20):\n",
+    "    for center_column in np.arange(10, 200, 20):\n",
+    "        shape_type = rng.choice([\"square\", \"circle\"])\n",
+    "        if shape_type == \"square\":\n",
+    "            shape_function = get_square_indices\n",
+    "            ground_truth.append(1)\n",
+    "        else:\n",
+    "            shape_function = get_circle_indices\n",
+    "            ground_truth.append(2)\n",
+    "        shape_rows, shape_columns = shape_function(center_row, center_column, half_width=5)\n",
+    "        \n",
+    "        label_image[shape_rows, shape_columns] = label_index\n",
+    "    \n",
+    "        label_index += 1\n",
+    "\n",
+    "ground_truth = np.asarray(ground_truth)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "aa84dfbf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQEAAAD8CAYAAAB3lxGOAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAXuUlEQVR4nO3dfZQU1ZkG8OcJUWL8WDXIiOAqKmEj6pkFNZoQkBiNgiu6JyrmAww5oBzZJYmr0dUQg3qSaNToYjDDCQucRAHNmrCBKIS4uOxqwkdYPlTCqHgEYUY0KzEaDfjuH10de6eruu5UdU1V931+5/SZmVt3am6L95nqvu/UpZlBRPz1vrwHICL5UgiIeE4hIOI5hYCI5xQCIp5TCIh4LrMQIHkeyS0k20len9XPEZF0mEWdAMleAH4H4BwA2wGsBnC5mT1d9x8mIqlkdSVwOoB2M3vezN4BsADA2Ix+loik8P6MztsfwEsVX28H8NGoziRVtiiSvd1mdkTXxqxCIBbJyQAm5/XzRTz0YlhjViGwA8DRFV8PCNr+wszaALQBuhIQyVNW7wmsBjCI5ECS+wMYB2BxRj9LRFLI5ErAzPaSnArgMQC9AMwxs81Z/CwRSSeTJcJuDyLk5cDjw//k/P2jVn2gruMpkq1P93LuO+jEfc59T/4n9wuzjd+90LlvFobtbHfuu7bfCRmOxM0Z125y7vvUHSc59x1z5MPOfZfs+kxY81ozO7VroyoGRTyX2+pAUbxyRVtV2xFz0y1anPLi2aHtG45Zkeq8jeahTx5U1XbJr97IYSTxPjz4O6Htv9vytR4eSc/z9krglSvaQgOgfCypqACIO9ZswgKgVnueogIg7liz8DIEXCZ5kiBwmeQ+BEHcRC9SELhM8mYPAi9DQETeoxAQ8ZxCQMRzCgERz3kZAi5LgEmWCV2WAH1YJoxbBizSMqHLEmCzLxN6GQJAaZJHTfQ0dQK1JrkPAVAWNdGLFABltSZ5swcAUOCyYRGpO5UNi0g1hYCI5xQCIp5TCIh4TiEg4jmFgIjnFAIinkscAiSPJvk4yadJbiY5LWi/meQOkuuDx+j6DVdE6i3NnYX2ArjGzNaRPBjAWpLLg2N3m9l30w9PRLKWOATMbCeAncHnfyD5DEo7D4lIA6nLPQZJHgvgbwH8GsDHAUwlOR7AGpSuFn5fj58jUk/XDfqyc9/bt34vs3G46n3n2859376mt3Pf1CFA8iAAPwHwZTPbQ3IWgFsAWPDxTgATQ76vW9uQzet7ZVXbhM4fJBz1e1ZMPreq7ey2ZanOeensP4S2L5p0cKrzPrEv/PtH9Ar/ea4mzai+3dfs6en/0Gff/VOr2npdNTP1eaeuXFDVNnPkuNTnzcLuV8LfEutzxNIeHkm0VKsDJPdDKQB+bGb/BgBm1mFm+8zsXQCzUdqhuIqZtZnZqWF/0NBVWADUanexYvK5oQFQPpZUVADEHYsTFQBxx+KEBUCtdldhAVCr3cXUlQtCA6B8rGiiAiDuWE9LszpAAD8E8IyZ3VXR3q+i28UA3HdiEJEel+ZK4OMAvgDgk12WA28nuZHkBgCjAHwlzQDjftsnuRpw+U2f5GrA5Td9kqsBl9/0Sa4G4n7bT5pxUKIrgrjf9kmuBlx+0xfpasDlN31RrgbSrA6sAsCQQ8V5sSMisVQxKOI5hYCI5xQCIp4rfAjE1QIkqRVwqQNIUivgUgeQpFbApQ4gSa1AXC3A7OlvJKoXiKsFSFIr4FIHUKRaAZc6gKLUChQ+BIDoiZ6mWOjstmWREz1NsVCtSZ6mWKjWJE9TLBQ1ydMWC0VN9DTFQjNHjouc6EUKgLJak7woAQDobsMiPtHdhkWkmkJAxHMKARHPKQREPKcQEPGcQkDEcwoBEc8pBEQ8pxAQ8ZxCQMRzdbnbcCO59ucfde57xwW/du7788mdzn0vaOvr3FeAubc849z3iq9/JMOR5OuMxe436Xrqwrud+zZMCEw45Laqtnl7bsxhJPn5q4cuDG1//ZLFqc478KHLqtpeuGRhqnMCwNJzh1W1jV62NvV5szD8o/eEtq/69bRU5z3hra+Ftrcf8J1U562nhng5EBYAtdqbUVQAxB2LExYAtdpdhQVArfY8RQVA3LE4UQEQd6ynpQ4BktuCG4uuJ7kmaDuc5HKSW4OPhyU9f9xE9yEIXCZ5kiCIm+gDH7osURjETfQiBYHLJE8SBC6TvChBUK8rgVFm1lrxZ4rXA1hhZoMArAi+FpECyurlwFgA84LP5wG4KKOfIyIp1SMEDMAykmuDrcUAoCXYsBQAdgFo6fpNJCeTXFN+CSEi+ajH6sBwM9tBsi+A5SSfrTxoZhZ25yAzawPQBujOQiJ5Sn0lYGY7go+dAB5Bae/BjvJ2ZMFH90V0EelRaTckPZDkweXPAZyL0t6DiwFMCLpNAPCzpD8jrhbAh1oBlzqAJLUCcbUAL1yyMFG9QFwtQJFqBVzqAJLUCrjUARSlViDtlUALgFUk/wfAbwAsMbNHAXwbwDkktwL4VPB1YlET3YcAKKs1ydMUC0VN8rTFQlETvUgBUFZrkqcpFqo1yYsSAIDuNiziE91tWESqKQREPKcQEPGcQkDEcwoBEc8pBEQ8pxAQ8ZxCQMRzCgERzykERDxX2BuNTnlyhnPfWWdOd+57/HW3Ovd97vabnPtunLbPue/J9/Ry7ttI7hpxiHPfrz6xJ8OR5OsHC/o5971y3M74ThkrbAhItV3Tx4S2HzljSarzjrztT1VtK2/8QKpzZmnGZdV/mT59YbrbuI9pfzS0fckJ56U6b1au7vtmVdt9nR9MdC69HGgQUQEQdyxOWADUas/TjMs6QwOgfCypqACIO5aXsACo1R5HIdAAXCZ5kiCIm+gjb/tTYcLAZZInCQKXSV6kIIib6Ff3fbPbYaAQEPGcQkDEcwoBEc8pBEQ8l3iJkORgAJU3ojsOwHQAhwKYBOCVoP2fzWxp0p8jItlKfCVgZluCrcdaAQwD8CZKtxwHgLvLxxQA6bnUASSpFYirBVh54wcKUy/gUgeQpFbApQ6gSLUCcbUA93V+sNv1AvV6OXA2gOfM7MU6nU+6qDXJ0xQLRU3yokz+StMX9o2c6GmKhWpN8iIFQFnUJE9aLFSXuw2TnANgnZnNJHkzgCsA7AGwBsA1Zvb7kO+ZDKC8bVlxtqkVaV6hdxtOHQIk9wfwMoAhZtZBsgXAbpT2KLwFQD8zmxhzDt1yXCR7md1y/HyUrgI6AMDMOsxsn5m9C2A2StuSiUhB1SMELgfwYPmL8h6EgYtR2pZMRAoq1V8RBvsPngPgyorm20m2ovRyYFuXYyJSMNqGTMQf2oZMRKopBEQ8pxAQ8ZxCQMRzCgERzxX2RqN/1zrAue+/r9+e4UjydV2v2c59b983ybnvgHvc73K7fZr73XOz8C9vLXLu+w8HXJrhSJpTYUOgp6x+4JiqttM+m+7voOZ/aEFo+/hXx6U6b6PpP+KSqrYdTzyUw0ji/dejE0LbP37evFTnXX3At0LbT3vrhlTnfXn4lqq2o1YNTnQub18OrH7gmNAAKB9LKioA4o41m7AAqNWep6gAiDsWJyoA4o7FCQuAWu1xvAwBl0meJAhcJrkPQRA30YsUBC6TPEkQuEzyJEEQN9FfHr6l22HgZQiIyHsUAiKeUwiIeE4hIOI5L0PAZQkwyTKhyxKgD8uEccuARVomdFkCTLJM6LIEmGSZMG4Z8KhVg7u9VOhlCAClSR410dPUCdSa5D4EQFnURC9SAJTVmuRp6gRqTfI0dQJRk1x1AiKSiG4qIuIP3VRERKo5hQDJOSQ7SW6qaDuc5HKSW4OPhwXtJHkvyXaSG0gOzWrwIpKe65XAXABdt2K5HsAKMxsEYEXwNVC6Bfmg4DEZwKz0wxSRrDiFgJk9AeC1Ls1jAZTfOp0H4KKK9vlW8hSAQ7vchlxECiTNewItZlb+o/RdAFqCz/sDeKmi3/agTUQKqC73EzAz6+47/F32IhSRnKS5EugoX+YHHzuD9h0Ajq7oNyBo+3/MrM3MTg1bshCRnpMmBBYDKP+h9QQAP6toHx+sEpwB4PWKlw0iUjRmFvtAaa/BnQD+jNJr/C8B+BBKqwJbAfwSwOFBXwK4D8BzADYCONXh/KaHHnpk/lgTNv+8qxh8c98xzn0/2Mv9bwhOenK1c99NZ57m3HfJmc5dMeZJ974zb/ob575Tb33Wqd9nTnvM+ZwPr/60c9+szLjjEOe+06/dk+FIeowqBkWkWsPcbfjW1u9Utd20/ms5jETyNnRtdf3ZumFTchhJvLsOPiW0/at/2JDqvB2tX69qa1l/S6JzNcSVQFgA1GqX5jR07azQACgfK5qoAIg7FicsAGq1xyl8CMRNdAWBH1wmeZGCwGWSJwmCuIne0fr1bodB4UNARLKlEBDxnEJAxHMKARHPFT4E4pYBtUzoB5clwCItE7osASZZJoxbBmxZf0u3lwoLHwJA9ERXAPhl3bApkRO9SAFQVmuSp6kTiJrkSesEvCsbFvGYyoZFpJpCQMRzCgERzykERDynEBDxnEJAxHMKARHPxYZAxBZkd5B8Nthm7BGShwbtx5J8i+T64HF/hmMXkTpwuRKYi+otyJYDOMnMTgHwOwCVm60/Z2atweOq+gxTRLISGwJhW5CZ2TIz2xt8+RRKewuISAOqxz0GJwJYWPH1QJK/BbAHwE1m9p91+BmFN3rMfs59ly75c4YjcTNhv9nOfef9eZJTv/dtdf9v8O6g/P8bvP2Se61976Pd79Zz5+a5zn2vGXKFc99VX5zo3Hf4v85x7psqBEjeCGAvgB8HTTsB/LWZvUpyGICfkhxiZlX3a+7uNmQjHq/u+sSotkTjrrToF89XtV16/nGpz5uFWbMODW2fMuV/e3QceZv/xstVbeMPOiqHkTSHxKsDJK8AcAGAz1l5BxGzt83s1eDztShtQPLhsO/vzjZkYQFQq93Fol88HxoA5WNFExUAcceayfw3Xg4NgPIxSSZRCJA8D8B1AC40szcr2o8g2Sv4/DgAgwAUb0aJyF+4LBE+COBJAINJbif5JQAzARwMYHmXpcARADaQXA/gYQBXmdlrYed1FffbPsnVgMtv+iJdDbj8pm/2qwGX3/S6Gkgm9j0BM7s8pPmHEX1/AuAnaQclIj1HFYMinlMIiHhOISDiucKHQFwtQJJaAZc6gCLVCrjUATR7rYBLHYBqBZIpfAgA0RM9TbHQpecfFznRixQAZbUmebMHQNn4g46KnOgKgOR0t2ERf+huwyJSTSEg4jmFgIjnFAIinlMIiHhOISDiOYWAiOcUAiKeUwiIeE4hIOK5etxtuKGMmb3bue+SSX2c+07vfMy574y+n3buO/HKW537zvnBTc59s3D9uged+357aNi9asL96sZLnPt+8raHnPt2fmaNc9++D8feCrNhNUwIfOqP1bdQ/uWB7rdglmi7Oo6tajuyZVuPj6MZPXnWj0Pbz/yPz6U67+DDP1vVtuW1BxKdK+k2ZDeT3FGx3djoimM3kGwnuYWk+6+8GsICoFa7uAsLgFrt4i4qAOKOxQkLgFrtcZJuQwYAd1dsN7YUAEieCGAcgCHB93y/fPfhpOImuoIgubiJvqvjWIVBQi6TPEkQxE30wYd/ttthkGgbshrGAlgQ7D/wAoB2AKd3a0Qi0qPSrA5MDXYlnkPysKCtP4CXKvpsD9pEpKCShsAsAMcDaEVp67E7u3sCkpNJriHp/hatiNRdohAwsw4z22dm7wKYjfcu+XcAOLqi64CgLewcztuQiUh2km5D1q/iy4sBlFcOFgMYR7I3yYEobUP2m3RDFJEsJd2G7HaSG0luADAKwFcAwMw2A1gE4GkAjwK42sz2pRlgXC2AagWSi6sFOLJlm+oFEnKpA0hSKxBXC7DltQe6XS/gsjpwuZn1M7P9zGyAmf3QzL5gZieb2SlmdqGZ7azof5uZHW9mg83sF90aTYSoia4ASC9qkmvyp1drkqcpFoqa5EmLhXS3YRF/6G7DIlJNISDiOYWAiOcUAiKeUwiIeE4hIOI5hYCI5xQCIp5TCIh4TiEg4rmGudFovbzdZ6Bz3967X3Du+62hM5373rBuqnNfAaZ+5CnnvjOfOcO575hvTHPuu+Sb9zj3bTQNEwLzNy6taht/8uiQns1rz4sdoe2HHNOS6rwTh66sapuzbmSqcwLA1m98uapt0De/l/q8jeTxAdeGto/afkeq835+/pSqth+Nn5XoXA3xciAsAGq1N6OoAIg7FicsAGq1uwoLgFrtzSgqAOKOxQkLgFrtcQofAnET3YcgcJnkSYIgbqJPHLoyURjETXQfgsBlkicJgriJ/vn5U7odBoUPARHJlkJAxHMKARHPJd2GbGHFFmTbSK4P2o8l+VbFsfszHLuI1IHLEuFcADMBzC83mNll5c9J3gng9Yr+z5lZa53GJyIZS7UNGUkCuBSA+57U3RRXC+BDrYBLHUCSWoG4WoA560YmqheIqwXwoVbApQ4gSa1AXC3Aj8bP6na9QNr3BD4BoMPMtla0DST5W5IrSX4i5fkBRE90HwKgrNYkT1MsFDXJ0xYLRU10HwKgrNYkT1MsFDXJkxYLwcxiHwCOBbAppH0WgGsqvu4N4EPB58NQ2pfwkIhzTgawJniYHnrokfljTdhcTHwlQPL9AP4ewMJyW7Ab8avB52sBPAfgw2Hfr23IRIohzcuBTwF41sy2lxtIHkGyV/D5cShtQ/Z8uiGKSJaSbkMGAONQ/YbgCAAbgiXDhwFcZWahbyqKSDFoByIRf2gHIhGpphAQ8ZxCQMRzCgERzykERDynEBDxXGFvNLr3HzfFdwq8/96TMhxJvlqn/dy57/p7LshwJPFW7vmjc9+Rhxzo3HfZR/o79z33mR3OfRvNPT99wbnvtIvc76pd2BDoKUM+Nq+qbfN/T0h1zrf2Pz20/YB3fpPqvFl5Z3d7Vdv+fU7IYST5WXtV+KQZdr/7xAvT/6uzQ9t33DUp1XnryduXA0M+Ni80AMrHkooKgLhjeQkLgFrtzSgqAOKOxYkKgLhjPc3LEHCZ5EmCwGWSFykI4ib6O7vbmz4MXCZ5kiBwmeRFCQIvQ0BE3qMQEPGcQkDEcwoBEc95GQIuS4BJlgldlgCLtEwYtwy4f58Tmn6p0GUJMMkyocsSYFGWCb0MAaA0yaMmepo6gVqTvEgBUBY1yZt98leqNcnT1AnUmuRFCQDA4xAQkRLdWUjEH7qzkIhUUwiIeE4hIOI5hYCI54ryp8S7Afwx+Nhs+qA5nxfQvM+tWZ/XMWGNhVgdAACSa5pxS7JmfV5A8z63Zn1eUfRyQMRzCgERzxUpBNryHkBGmvV5Ac373Jr1eYUqzHsCIpKPIl0JiEgOcg8BkueR3EKyneT1eY8nLZLbSG4kuZ7kmqDtcJLLSW4NPh6W9zjjkJxDspPkpoq20OfBknuDf8MNJIfmN/J4Ec/tZpI7gn+39SRHVxy7IXhuW0h+Op9RZyfXECDZC8B9AM4HcCKAy0memOeY6mSUmbVWLDNdD2CFmQ0CsCL4uujmAjivS1vU8zgfwKDgMRnArB4aY1JzUf3cAODu4N+t1cyWAkDw/+M4AEOC7/l+8P9t08j7SuB0AO1m9ryZvQNgAYCxOY8pC2MBlG9fPA/ARfkNxY2ZPQHgtS7NUc9jLID5VvIUgENJ9uuRgSYQ8dyijAWwwMzeNrMXALSj9P9t08g7BPoDeKni6+1BWyMzAMtIriU5OWhrMbOdwee7ALTkM7TUop5Hs/w7Tg1ezsypeMnWLM8tUt4h0IyGm9lQlC6RryY5ovKglZZjGn5JplmeR4VZAI4H0ApgJ4A7cx1ND8o7BHYAOLri6wFBW8Mysx3Bx04Aj6B06dhRvjwOPnbmN8JUop5Hw/87mlmHme0zs3cBzMZ7l/wN/9zi5B0CqwEMIjmQ5P4ovQGzOOcxJUbyQJIHlz8HcC6ATSg9p/KNCycA+Fk+I0wt6nksBjA+WCU4A8DrFS8bGkKX9zAuRunfDSg9t3Eke5MciNKbn8W7WWQKuf4VoZntJTkVwGMAegGYY2ab8xxTSi0AHiEJlP7bPmBmj5JcDWARyS8BeBHApTmO0QnJBwGcBaAPye0AvgHg2wh/HksBjEbpTbM3AXyxxwfcDRHP7SySrSi9xNkG4EoAMLPNJBcBeBrAXgBXm9m+HIadGVUMingu75cDIpIzhYCI5xQCIp5TCIh4TiEg4jmFgIjnFAIinlMIiHju/wCTvkwfCM0jRwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# view the label image\n",
+    "cle.imshow(label_image, labels=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5f6786bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# measure the  using skimage's regionprops_table function\n",
+    "measurement_table = regionprops_table(label_image, properties=(\"label\", \"area\", \"perimeter\"))\n",
+    "labels = measurement_table.pop(\"label\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "64923b38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# extract the first 50 measurements to use as training\n",
+    "measurements_training = {key: values[0:50] for key, values in measurement_table.items()}\n",
+    "ground_truth_training = ground_truth[0:50]\n",
+    "\n",
+    "# create the classifier and train it\n",
+    "cl_filename = \"shape_classifier.model.cl\"\n",
+    "apoc.erase_classifier(cl_filename)\n",
+    "classifier = apoc.TableRowClassifier(cl_filename)\n",
+    "classifier.train(measurements_training, ground_truth_training)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d01400b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQEAAAD8CAYAAAB3lxGOAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAQl0lEQVR4nO3dfawc1X3G8e9TJ/BHSgUk1KJAi0EOEqSRC4hGCkGhDQmgKob+kRpFwSmoDhJIaYRUQVu1SFGliJaiRCSOjLAwUsuLggArdQHXqpIilcJ14pqX4Ni8CTvGLhBBVaKkhl//mLlhe+/ee/fOzNmds+f5SKu7e3b37Jk5659md9bPUURgZuX6lUkPwMwmy0XArHAuAmaFcxEwK5yLgFnhXATMCpesCEi6WNIeSfsk3ZDqdcysHaX4nYCkFcCPgYuA/cCTwBUR8WznL2ZmraQ6EjgP2BcRL0TEL4B7gLWJXsvMWnhfon5PAl4ZuL0f+N2FHizJP1s0S++1iDhhbmOqIrAkSRuADZN6fbMCvTysMVUROACcMnD75LrtlyJiE7AJfCRgNkmpvhN4ElgtaZWko4B1wNZEr2VmLSQ5EoiII5KuAx4BVgCbI+KZFK9lZu0kOUW47EEM+Tjwk/P3jPz833jsjE7H0yep9kNO+zensUKv52xnRJw7t9G/GDQr3MTODvTF1x98cV7bly9b1XmfXfSbmxT7NpWS56zYI4GvP/jighO/UPuo/Ta5b9qk2LeplD5nRRaBUSa2yeSn6jc3S21jn/aB56zQImBm73ERMCuci4BZ4VwEzApXZBEY5bRPk1NDqfrNzVLb2Kd94DkrtAhANbELTW6bSV/sudP+ZhqUYt+mUvqc9fZnw2bWOf9s2MzmcxEwK5yLgFnhXATMCuciYFY4FwGzwrkImBWucRGQdIqkf5X0rKRnJH25br9J0gFJu+rLpd0N18y61iZZ6AhwfUT8QNIxwE5J2+v7bo2Iv2s/PDNLrXERiIiDwMH6+n9L+hHVykNmlpFOMgYlnQr8DvAfwMeB6yRdCcxQHS38tIvXMeuSU4wrrYuApF8F7gf+NCLekrQR+CoQ9d9bgKuGPG9Zy5ClCq3MKWh0nP32dd+m7DeFHAJMW/0HIknvB74LPBIRfz/k/lOB70bER5boZ9FBLJbx1nRnLpUb537bvVFzmLPURwI9HG+3/4FIkoA7gB8NFgBJJw487HLg6aavYWbptfmdwMeBLwC/N+d04M2SnpK0G7gQ+EqbAaZIrs0tbXhS/S4Wy9623677bNpvKjmNt83ZgccADblrW/PhmNm4+ReDZoVzETArnIuAWeF6XwRSJNfmljY8qX4XC2Nt22/XfTbtN5Wcxtv7IgBpkmtzSxsed79t36A5zVkquaQYO23YrBxOGzaz+VwEzArnImBWOBcBs8K5CJgVzkXArHAuAmaFcxEwK5yLgFnhXATMCtdJ2nBOUuXK5ZZcmxPv20pv04bHJaeE2VScNpxObgnRXcri48BCO7IvGW3jsNi2ttkPqfZtTnM27n3btt+utS4Ckl6qg0V3SZqp246XtF3S3vrvcU37TxFamRsHjaaTWzhsCl0dCVwYEWsG/pviDcCOiFgN7Khvm1kPpfo4sBbYUl/fAlyW6HXMrKUuikAAj0raWS8tBrCyXrAU4FVg5dwnSdogaWb2I4SZTUYXZwfOj4gDkn4d2C7pucE7IyKGJQdFxCZgEzhZyGySWh8JRMSB+u9h4AHgPODQ7HJk9d/DbV/HzNJoVQQkfUDSMbPXgU9TrT24FVhfP2w98FDT10iRXJsbpw2nk1tCdAptjwRWAo9J+k/gCeCfIuJh4GvARZL2Ap+qbzeWU8JsKk4bTie3hOiuOW3YrBxOGzaz+VwEzArnImBWOBcBs8K5CJgVzkXArHAuAmaFcxEwK5yLgFnhXATMCtfboNHcUoGdiOt9MCu3/dDbImDz5ZY2nEqK8eaQCjyoy33gjwOZyC1tOIXFgk9LSAWe1fU+cBHIQG5pwyk4FbiSYs5cBMwK5yJgVjgXAbPCuQiYFa7xKUJJZwD3DjSdBvwVcCzwJ8B/1e1/HhHbmr6OmaXV+EggIvbUS4+tAc4B3qaKHAe4dfY+F4D2cksbTsGpwJUUc9bVx4HfB56PiJc76s/myC1tOIXF3uAlpALP6nofdJI2LGkz8IOIuE3STcAXgbeAGeD6iPjpkOdsAGaXLTun9SDMbClD04ZbFwFJRwE/Ac6KiEOSVgKvUa1R+FXgxIi4aok+HDlull6yyPFLqI4CDgFExKGIeCci3gVup1qWzMx6qosicAVw9+yN2TUIa5dTLUtmZj3V6n8R1usPXgR8aaD5ZklrqD4OvDTnPjPrGS9DZlYOL0NmZvO5CJgVzkXArHAuAmaFcxEwK1xvg0ZzS2xNxenIeY01R70tAuPi5Np0ckoxHmeSc6p+nTa8TE6uTSu3FOMm9/WtX6cNL4OTa9MaJRG3L3J7Lzht2Mw65yJgVjgXAbPCuQiYFa7IIuDQyrRGCcPsi9zeC30OGs2OQyvTyi3AtMl9fevXvxMws0YcKmJWDoeKmNl8IxUBSZslHZb09EDb8ZK2S9pb/z2ubpekb0jaJ2m3pLNTDd7M2hv1SOBO4OI5bTcAOyJiNbCjvg1VBPnq+rIB2Nh+mGaWykhFICK+D7wxp3ktsKW+vgW4bKD9rqg8Dhw7J4bczHqkzXcCKyPiYH39VWBlff0k4JWBx+2v28yshzrJE4iIWO43/HPWIjSzCWlzJHBo9jC//nu4bj8AnDLwuJPrtv8nIjZFxLnDTlmY2fi0KQJbgfX19fXAQwPtV9ZnCT4GvDnwscHM+iYilrxQrTV4EPhfqs/4VwMfpDorsBf4F+D4+rECvgk8DzwFnDtC/+GLL74kv8wM+/dX3C8GcwvuzKnf3AJBcxtvB/yLQTObL5u04ZySay2tnN4LThvuSE7JtZZOqoToVJw23JGckmstndySnJ02bGbZcBEwK5yLgFnhXATMCtf7IpBTcq2lk1uSs9OGO5ZTcq2lkyohOpVc0oaL+9mwWcH8s2Ezm89FwKxwLgJmhXMRMCuci4BZ4VwEzArnImBWuCWLwAJLkP2tpOfqZcYekHRs3X6qpJ9J2lVfvp1w7GbWgVGOBO5k/hJk24GPRMRHgR8DNw7c93xErKkv13QzTDNLZckiMGwJsoh4NCKO1Dcfp1pbwMwy1EXG4FXAvQO3V0n6IfAW8JcR8W8dvEbv5ZZc67ThvJKcU/bbqghI+gvgCPAPddNB4Dcj4nVJ5wAPSjorIt4a8txlLUOWKlzSoZX5yWnOctD47ICkLwJ/AHw+ZlcQifh5RLxeX99JtQDJh4c9fznLkKUIl3RoZX5ym7NcNCoCki4G/gz4bES8PdB+gqQV9fXTgNXAC10M1MzSGOUU4d3AvwNnSNov6WrgNuAYYPucU4EXALsl7QK+A1wTEW8M63dUKdKGnVybH++DdJb8TiAirhjSfMcCj70fuL/toMxsfPyLQbPCuQiYFc5FwKxwvS8CKdKGnVybH++DdHpfBCBN2rCTa/OT25zlwmnDZuVw2rCZzeciYFY4FwGzwrkImBXORcCscC4CZoVzETArnIuAWeFcBMwK5yJgVrgu0oazklsSbE4Jvrntg5z2bUrZFAEnzKbjfZtOqoToLues6TJkN0k6MLDc2KUD990oaZ+kPZI+02hUczhhNh3v23RSJUR3PWdNlyEDuHVgubFtAJLOBNYBZ9XP+dZs+nBTKYJGrTLKvvX+bSZVMGqKOWu0DNki1gL31OsPvAjsA85b1ojMbKzanB24rl6VeLOk4+q2k4BXBh6zv24zs55qWgQ2AqcDa6iWHrtluR1I2iBpRtJMwzGYWQcaFYGIOBQR70TEu8DtvHfIfwA4ZeChJ9dtw/oYeRkyM0un6TJkJw7cvByYPXOwFVgn6WhJq6iWIXui3RDNLKWmy5DdLOkpSbuBC4GvAETEM8B9wLPAw8C1EfFOmwGmSBu2yij71vu3mVTpyCnmbJSzA1dExIkR8f6IODki7oiIL0TEb0fERyPisxFxcODxfxMRp0fEGRHxz8sazQKcMJuO9206qRKiu54zpw2blcNpw2Y2n4uAWeFcBMwK5yJgVjgXAbPCuQiYFc5FwKxwLgJmhXMRMCuci4BZ4bIJGu2Kk2vz4zlLK5si4ETcPJJrx9FvTnKYsyw+DjgRN5/k2tT95iSXOet9EXDacF7JtaP2O+1ymrPeFwEzS8tFwKxwLgJmhWu6DNm9A0uQvSRpV91+qqSfDdz37YRjN7MOjHKK8E7gNuCu2YaI+KPZ65JuAd4cePzzEbGmo/GZWWKtliGTJOBzwN0dj+uXnDacV3LtqP1Ou5zmrO13Ap8ADkXE3oG2VZJ+KOl7kj7Rsn/AibiQT3Jt6n5zks2cRcSSF+BU4Okh7RuB6wduHw18sL5+DtW6hL+2QJ8bgJn6Er744kvyy8ywf4uNjwQkvQ/4Q+De2bZ6NeLX6+s7geeBDw97vpchM+uHNh8HPgU8FxH7ZxsknSBpRX39NKplyF5oN0QzS6npMmQA65j/heAFwO76lOF3gGsiYuiXimbWD16ByKwcXoHIzOZzETArnIuAWeFcBMwK5yJgVjgXAbPC9TZo1EmwlZz2g1OB00q1H3pbBMYlRSJuqoTZVJwKPN5U4C767VKxHwcWC2RMkQTbtt9UnAo8/lTgtv12rcgiMKkk2Kb9ppIqbTgnfi8UWgTM7D0uAmaFcxEwK5yLgFnhiiwCkwqBbNpvKqmCRnPi90KhRQAWf4OnCIFs228qDgQdfyBo2367VmwRMLOKk4XMyuFkITObz0XArHAuAmaFcxEwK1xf/ivxa8D/1H+nzYeYzu2C6d22ad2u3xrW2IuzAwCSZqZxSbJp3S6Y3m2b1u1aiD8OmBXORcCscH0qApsmPYBEpnW7YHq3bVq3a6jefCdgZpPRpyMBM5uAiRcBSRdL2iNpn6QbJj2etiS9JOkpSbskzdRtx0vaLmlv/fe4SY9zKZI2Szos6emBtqHboco36jncLensyY18aQts202SDtTztkvSpQP33Vhv2x5Jn5nMqNOZaBGQtAL4JnAJcCZwhaQzJzmmjlwYEWsGTjPdAOyIiNXAjvp2390JXDynbaHtuARYXV82ABvHNMam7mT+tgHcWs/bmojYBlC/H9cBZ9XP+Vb9vp0akz4SOA/YFxEvRMQvgHuAtRMeUwprgS319S3AZZMbymgi4vvAG3OaF9qOtcBdUXkcOFbSiWMZaAMLbNtC1gL3RMTPI+JFYB/V+3ZqTLoInAS8MnB7f92WswAelbRT0oa6bWVEHKyvvwqsnMzQWltoO6ZlHq+rP85sHvjINi3btqBJF4FpdH5EnE11iHytpAsG74zqdEz2p2SmZTsGbAROB9YAB4FbJjqaMZp0ETgAnDJw++S6LVsRcaD+exh4gOrQ8dDs4XH99/DkRtjKQtuR/TxGxKGIeCci3gVu571D/uy3bSmTLgJPAqslrZJ0FNUXMFsnPKbGJH1A0jGz14FPA09TbdP6+mHrgYcmM8LWFtqOrcCV9VmCjwFvDnxsyMKc7zAup5o3qLZtnaSjJa2i+vLziXGPL6WJ/i/CiDgi6TrgEWAFsDkinpnkmFpaCTwgCap9+48R8bCkJ4H7JF0NvAx8boJjHImku4FPAh+StB/4a+BrDN+ObcClVF+avQ388dgHvAwLbNsnJa2h+ojzEvAlgIh4RtJ9wLPAEeDaiHhnAsNOxr8YNCvcpD8OmNmEuQiYFc5FwKxwLgJmhXMRMCuci4BZ4VwEzArnImBWuP8DcuE6MSaCJdEAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# predict on the full table\n",
+    "prediction = classifier.predict(measurement_table)\n",
+    "\n",
+    "# create an image where the objects are colored by the predicted shape\n",
+    "shape_image = np.zeros_like(label_image)\n",
+    "for label_index, predicted_shape in zip(labels, prediction):\n",
+    "    shape_image[label_image == label_index] = predicted_shape\n",
+    "\n",
+    "cle.imshow(shape_image, labels=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+numpy
 scikit-learn>=0.24.2
 pyclesperanto-prototype>=0.8.0

--- a/tests/test_generate_label_features.py
+++ b/tests/test_generate_label_features.py
@@ -20,7 +20,7 @@ def test_label_feature_generation():
     assert len(table) == 1
 
     # there are three area measurements
-    assert len(table[0][0]) == 3
+    assert len(np.squeeze(table["area"])) == 3
 
 
 def test_label_feature_generation_with_annotated_background():
@@ -45,4 +45,4 @@ def test_label_feature_generation_with_annotated_background():
     assert len(table) == 1
 
     # there are three area measurements
-    assert len(table[0][0]) == 3
+    assert len(np.squeeze(table["area"])) == 3

--- a/tests/test_object_classification.py
+++ b/tests/test_object_classification.py
@@ -1,4 +1,6 @@
 import numpy as np
+
+
 def test_object_classification():
     image      = np.asarray([[0,0,1,1,2,2,3,3,3,3,3]])
     labels     = np.asarray([[0,0,1,1,1,1,2,2,2,2,2]])

--- a/tests/test_table_row_classification.py
+++ b/tests/test_table_row_classification.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pandas as pd
+
+feature_table_dict = {
+    "area": np.array([10, 10, 30, 30, 10]),
+    "surface_area": np.array([5, 3, 80, 80, 9])
+}
+feature_table_data_frame = pd.DataFrame(feature_table_dict)
+ground_truth = np.array([1, 1, 2, 2, 1])
+
+
+def test_table_row_classification_from_dict():
+    """Test the TableRowClassifier when the train/predict data are
+    a dictionary with keys for columns names and columns stored
+    as numpy arrays.
+    """
+
+    import apoc
+    oc = apoc.TableRowClassifier()
+    oc.train(
+        feature_table=feature_table_dict,
+        gt=ground_truth,
+        continue_training=False
+    )
+    result = oc.predict(feature_table_dict, return_numpy=True)
+
+    assert result.dtype == np.uint32
+
+    print(result)
+
+    assert np.allclose(ground_truth, result)
+
+
+def test_table_row_classification_from_dataframe():
+    """Test the TableRowClassifier when the train/predict data
+    are a pandas dataframe.
+    """
+    import apoc
+    oc = apoc.TableRowClassifier()
+    oc.train(
+        feature_table=feature_table_data_frame,
+        gt=ground_truth,
+        continue_training=False
+    )
+    result = oc.predict(feature_table_dict, return_numpy=True)
+
+    assert result.dtype == np.uint32
+
+    print(result)
+
+    assert np.allclose(ground_truth, result)

--- a/tests/test_table_row_classification.py
+++ b/tests/test_table_row_classification.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 feature_table_dict = {
     "area": np.array([10, 10, 30, 30, 10]),
@@ -9,43 +10,22 @@ feature_table_data_frame = pd.DataFrame(feature_table_dict)
 ground_truth = np.array([1, 1, 2, 2, 1])
 
 
-def test_table_row_classification_from_dict():
+@pytest.mark.parametrize("feature_table", [feature_table_dict, feature_table_data_frame])
+def test_table_row_classification(tmpdir, feature_table):
     """Test the TableRowClassifier when the train/predict data are
     a dictionary with keys for columns names and columns stored
     as numpy arrays.
     """
 
     import apoc
-    oc = apoc.TableRowClassifier()
+    opencl_file = tmpdir.join("test.cl")
+    oc = apoc.TableRowClassifier(opencl_file)
     oc.train(
-        feature_table=feature_table_dict,
+        feature_table=feature_table,
         gt=ground_truth,
         continue_training=False
     )
-    result = oc.predict(feature_table_dict, return_numpy=True)
+    result = oc.predict(feature_table, return_numpy=True)
 
     assert result.dtype == np.uint32
-
-    print(result)
-
-    assert np.allclose(ground_truth, result)
-
-
-def test_table_row_classification_from_dataframe():
-    """Test the TableRowClassifier when the train/predict data
-    are a pandas dataframe.
-    """
-    import apoc
-    oc = apoc.TableRowClassifier()
-    oc.train(
-        feature_table=feature_table_data_frame,
-        gt=ground_truth,
-        continue_training=False
-    )
-    result = oc.predict(feature_table_dict, return_numpy=True)
-
-    assert result.dtype == np.uint32
-
-    print(result)
-
     assert np.allclose(ground_truth, result)


### PR DESCRIPTION
As discussed in #8, this PR adds a classifier for performing classification on rows of a feature table.

Currently, this will accept tables as both pandas DataFrame and a dictionary where the column names are keys and the columns are arrays.

I've added tests that show both table types in `tests/test_table_row_classification.py`. It looks like pytest isn't currently being used, but I think it would be nice to convert the tests in a future PR.

This PR closes #8