### PR TITLE
Clarify ObjectClassifier._select_features() behavior

### DIFF
--- a/apoc/_object_classifier.py
+++ b/apoc/_object_classifier.py
@@ -181,9 +181,14 @@ class ObjectClassifier():
         Returns
         -------
         result:list[vector]
-            list of vectors corresponding to the requested features. The vectors are shaped (n) for n labels that
-            were annotated. Labels without annotation are removed from the vectors.
-            Background measurements are removed, because background cannot be classified.
+            list of vectors corresponding to the requested features.
+            If ground_truth is not None:
+                The vectors are shaped (n) for n labels that were annotated. Labels without annotation
+                are removed from the vectors. Background measurements are removed,
+                because background cannot be classified.
+            If ground_truth is None:
+                The vectors are shaped (n+1) for n labels.
+                That is, background + n measurements for n labels.
         ground_truth: ndimage
             selected elements of provided ground truth where it's not 0
         """

--- a/tests/test_generate_label_features.py
+++ b/tests/test_generate_label_features.py
@@ -46,3 +46,24 @@ def test_label_feature_generation_with_annotated_background():
 
     # there are three area measurements
     assert len(table[0][0]) == 3
+
+
+def test_label_feature_generation_for_prediction():
+    import numpy as np
+    import apoc
+
+    image = np.asarray([[0, 0, 1, 1, 2, 2, 3, 3, 3, 3, 3]])
+    labels = np.asarray([[0, 0, 1, 1, 1, 1, 3, 2, 2, 2, 2]])
+
+    feature_definition = """
+            area
+            """.replace("\n", " ")
+
+    oc = apoc.ObjectClassifier()
+    table, _ = oc._make_features(feature_definition, labels, None, image)
+
+    # we only measured area, 1 feature
+    assert len(table) == 1
+
+    # there are four area measurements: background + 3 labels
+    assert len(table[0][0]) == 4

--- a/tests/test_generate_label_features.py
+++ b/tests/test_generate_label_features.py
@@ -45,7 +45,7 @@ def test_label_feature_generation_with_annotated_background():
     assert len(table) == 1
 
     # there are three area measurements
-    assert len(table[0][0]) == 3
+    assert len(table["area"][0]) == 3
 
 
 def test_label_feature_generation_for_prediction():
@@ -66,4 +66,4 @@ def test_label_feature_generation_for_prediction():
     assert len(table) == 1
 
     # there are four area measurements: background + 3 labels
-    assert len(table[0][0]) == 4
+    assert len(table["area"][0]) == 4


### PR DESCRIPTION
Hello @haesleinhuepf . This PR adds a test and a slight docstring clarification related to #10 and #13. In fixing up the tests for #12 , I noticed that `ObjectClassifier._select_features()` returns two different numbers of features:

- When ground truth is provided, it returns n measurements for n labels
- When no ground truth is provided (e.g., when calling `ObjectClassifier.predict()`), it returns n+1 measurements for n features. That is background + 1 measurement per label

Is that the expected behavior? It works since there is code in `ObjectClassifier.predict()` to account for the additional measurement for the background ([here](https://github.com/haesleinhuepf/apoc/blob/32b84f86f73e7114e6ce7eb42571595e3e04e0b9/apoc/_object_classifier.py#L79-L80)). At some point, it might be nice to either create two separate functions or unify the behavior so the shape of the returned table is always the same.

