### PR TITLE
Fix prediction error in TableRowClassifers which were loaded from disc

### DIFF
--- a/apoc/_object_classifier.py
+++ b/apoc/_object_classifier.py
@@ -49,8 +49,13 @@ class ObjectClassifier():
 
         """
         self.classifier.feature_specification = features.replace(",", " ")
-        selected_features, gt = self._make_features(self.classifier.feature_specification, labels, sparse_annotation, image)
 
+        # remove too many spaces
+        while "  " in self.classifier.feature_specification:
+            self.classifier.feature_specification = self.classifier.feature_specification.replace("  ", " ")
+        self.classifier.feature_specification = self.classifier.feature_specification.strip()
+
+        selected_features, gt = self._make_features(self.classifier.feature_specification, labels, sparse_annotation, image)
         self.classifier.train(selected_features, gt, continue_training=continue_training)
 
     def predict(self, labels, image=None):

--- a/apoc/_table_row_classifier.py
+++ b/apoc/_table_row_classifier.py
@@ -38,6 +38,12 @@ class TableRowClassifier:
             overwrite_classname=self.classifier_classname
         )
 
+        # in case file existed, read feature specification from classifier
+        from os.path import exists
+        if exists(opencl_filename):
+            self.feature_specification = self.classifier.feature_specification
+            self._ordered_feature_names = self.feature_specification.replace(",", " ").split(" ")
+
     @property
     def ordered_feature_names(self) -> List[str]:
         """The feature names used in the order they are used by the classifier.
@@ -88,6 +94,7 @@ class TableRowClassifier:
         ordered_features = self._prepare_feature_table(feature_table)
         self.classifier.train(ordered_features, gt, continue_training=continue_training)
         self.classifier.to_opencl_file(self.classifier.opencl_file, overwrite_classname=self.classifier_classname)
+        self.feature_specification = self.classifier.feature_specification
 
     def predict(
             self,
@@ -155,11 +162,8 @@ class TableRowClassifier:
             The features stored in a list. The order of the features is
             specified by self.ordered_feature_names
         """
-        if len(self._ordered_feature_names) == 0:
-            # if the feature names haven't previously been stored,
-            # store them as a list
-            self._ordered_feature_names = list(feature_table.keys())
-            self.classifier.feature_specification = " ".join(self.ordered_feature_names)
+        self._ordered_feature_names = list(feature_table.keys())
+        self.classifier.feature_specification = " ".join(self.ordered_feature_names)
         return self.order_feature_table(feature_table)
 
     def order_feature_table(self, feature_table: Dict[str, np.ndarray]) -> List[np.ndarray]:

--- a/tests/test_table_row_classification.py
+++ b/tests/test_table_row_classification.py
@@ -29,3 +29,10 @@ def test_table_row_classification(tmpdir, feature_table):
 
     assert result.dtype == np.uint32
     assert np.allclose(ground_truth, result)
+
+    # rerun classifier from file
+    oc = apoc.TableRowClassifier(opencl_file)
+    result = oc.predict(feature_table, return_numpy=True)
+
+    assert result.dtype == np.uint32
+    assert np.allclose(ground_truth, result)


### PR DESCRIPTION
Hi @kevinyamauchi ,

I saw a bug in https://github.com/haesleinhuepf/napari-accelerated-pixel-and-object-classification/pull/11 which is fixed with this PR. Nothing serious, I'm just changing a bit how/when feature lists ("area min_intensity" etc) are read from file and/or updated when training the `TableRowClassifier`. I also added a test showing what was wrong before: Prediction didn't work when loading a classifier from a file.

Plus: The "too many spaces" thingy may be unrelated, but it broke another test during testing :-)

Let me know what you think!

Best,
Robert