### PR TITLE
Restore numpy<2.0 and scikit-learn<1.4.0 pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ authors = [
 ]
 requires-python = ">=3.8,<3.13"
 dependencies = [
-    "numpy>2.0",
-    "scikit-learn>1.4.0",
+    "numpy<2.0",
+    "scikit-learn>=0.24.2,<1.4.0",
     "pyclesperanto-prototype",
     "pandas>=2.0.0",
     "scikit-image>=0.22.0",


### PR DESCRIPTION
As per https://github.com/haesleinhuepf/apoc/commit/cb7667987dc4da966dc6efd3e4d7adedcc22e5c3#commitcomment-188122398